### PR TITLE
Trigger OpenID Connect challenge on refreshed options

### DIFF
--- a/OAuthTraining/Controllers/AccountController.cs
+++ b/OAuthTraining/Controllers/AccountController.cs
@@ -14,15 +14,18 @@ namespace OAuthTraining.Controllers
         private readonly IdpConfigRepository _repository;
         private readonly IDataProtector _protector;
         private readonly IOptionsMonitorCache<OpenIdConnectOptions> _optionsCache;
+        private readonly IOptionsMonitor<OpenIdConnectOptions> _optionsMonitor;
 
         public AccountController(
             IdpConfigRepository repository,
             IDataProtectionProvider provider,
-            IOptionsMonitorCache<OpenIdConnectOptions> optionsCache)
+            IOptionsMonitorCache<OpenIdConnectOptions> optionsCache,
+            IOptionsMonitor<OpenIdConnectOptions> optionsMonitor)
         {
             _repository = repository;
             _protector = provider.CreateProtector("IdpConfig.ClientSecret");
             _optionsCache = optionsCache;
+            _optionsMonitor = optionsMonitor;
         }
 
         [HttpGet]
@@ -30,7 +33,15 @@ namespace OAuthTraining.Controllers
         {
             if (await _repository.HasAnyAsync())
             {
-                return RedirectToAction("Index", "Home");
+                _optionsCache.TryRemove(OpenIdConnectDefaults.AuthenticationScheme);
+                _optionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme);
+
+                return Challenge(
+                    new AuthenticationProperties
+                    {
+                        RedirectUri = Url.Action("Index", "Home")
+                    },
+                    OpenIdConnectDefaults.AuthenticationScheme);
             }
 
             return View();
@@ -55,12 +66,7 @@ namespace OAuthTraining.Controllers
 
             _optionsCache.TryRemove(OpenIdConnectDefaults.AuthenticationScheme);
 
-            return Challenge(
-                new AuthenticationProperties
-                {
-                    RedirectUri = Url.Action("Index", "Home")
-                },
-                OpenIdConnectDefaults.AuthenticationScheme);
+            return RedirectToAction(nameof(Authenticate));
         }
     }
 }


### PR DESCRIPTION
## Summary
- inject IOptionsMonitor into AccountController alongside the existing options cache
- refresh the OpenID Connect options after saving configuration data so the challenge uses the new settings
- redirect the post to the authenticate GET so the challenge happens on a fresh request with the rebuilt options

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df8d47bd3c8327a8caff1b6e731602